### PR TITLE
NGX_HTTP_LIF_CONF and NGX_HTTP_SIF_CONF

### DIFF
--- a/ngx_http_js_challenge.c
+++ b/ngx_http_js_challenge.c
@@ -50,7 +50,7 @@ static ngx_command_t ngx_http_js_challenge_commands[] = {
 
         {
                 ngx_string("js_challenge"),
-                NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,
+                NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,,
                 ngx_conf_set_flag_slot,
                 NGX_HTTP_LOC_CONF_OFFSET,
                 offsetof(ngx_http_js_challenge_loc_conf_t, enabled),

--- a/ngx_http_js_challenge.c
+++ b/ngx_http_js_challenge.c
@@ -50,7 +50,7 @@ static ngx_command_t ngx_http_js_challenge_commands[] = {
 
         {
                 ngx_string("js_challenge"),
-                NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,,
+                NGX_HTTP_LOC_CONF | NGX_HTTP_LIF_CONF | NGX_HTTP_SIF_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,,
                 ngx_conf_set_flag_slot,
                 NGX_HTTP_LOC_CONF_OFFSET,
                 offsetof(ngx_http_js_challenge_loc_conf_t, enabled),


### PR DESCRIPTION
Hi,

Can we add NGX_HTTP_LIF_CONF and NGX_HTTP_SIF_CONF  to js_challenge ?

This will allow setting js_challenge on/off in the 'if' directive (on 'server' or 'location')


https://github.com/simon987/ngx_http_js_challenge_module/issues/8#issue-866768165
https://github.com/simon987/ngx_http_js_challenge_module/issues/10#issue-992356461

example:
```
http {
    ....
    geo $white_user {
        default 0;
        1.2.3.4/32 1;
        4.3.2.1/32 1;
        192.168.0.0/16 1;
    }
    server {
        ...
        js_challenge on;
        js_challenge_secret "test";
        js_challenge_html /var/www/html/loading.html;
        #js_challenge_bucket_duration 600;
        js_challenge_title "Verifying your browser...";
        ...  
                location / {
               ...
                          
                              if ($white_user){
                                    js_challenge off;      
                              } 
               ...
           }
      ...
}
```