### PR TITLE
Pass if GET /favicon.ico

### DIFF
--- a/ngx_http_js_challenge.c
+++ b/ngx_http_js_challenge.c
@@ -350,13 +350,19 @@ static ngx_int_t ngx_http_js_challenge_handler(ngx_http_request_t *r) {
     int ret = get_cookie(r, &cookie_name, &response);
 
     if (ret < 0) {
-        return serve_challenge(r, challenge, conf->html, conf->title);
+        //pass if request: "GET /favicon.ico HTTP/1.1"
+        if ( strncmp((char *)r->uri.data,"/favicon.ico",12) != 0){
+                return serve_challenge(r, challenge, conf->html, conf->title);
+        }
     }
 
     get_challenge_string(bucket, addr, conf->secret, challenge);
 
     if (verify_response(response, challenge) != 0) {
-        return serve_challenge(r, challenge, conf->html, conf->title);
+        //pass if request: "GET /favicon.ico HTTP/1.1"
+        if ( strncmp((char *)r->uri.data,"/favicon.ico",12) != 0){
+                return serve_challenge(r, challenge, conf->html, conf->title);
+        }
     }
 
     // Fallthrough next handler


### PR DESCRIPTION
Hi,

The browser will create a new request to get the favicon icon, and the challenge will be sent twice 

https://www.cisco.com/c/en/us/support/docs/security/web-security-appliance/117995-qna-wsa-00.html

example:
before:
```
2022/11/07 12:58:22 [error] 110162#0: *1 [ js challenge log ] sending challenger... , client: 192.168.110.158, server: domain.ro, request: "GET / HTTP/1.1", host: "www.domain.ro"
2022/11/07 12:58:22 [error] 110162#0: *1 [ js challenge log ] sending challenger... , client: 192.168.110.158, server: domain.ro, request: "GET /favicon.ico HTTP/1.1", host: "www.domain.ro", referrer: "https://www.domain.ro/"
```
after:
```
2022/11/07 13:02:24 [error] 110162#0: *1 [ js challenge log ] sending challenger..., res=-1 , client: 192.168.110.158, server: domain.ro, request: "GET / HTTP/1.1", host: "www.domain.ro"
```

To log I used https://github.com/simon987/ngx_http_js_challenge_module/pull/14

